### PR TITLE
update ami id to fix errors

### DIFF
--- a/docs/source/docker/docker-machine-aws.rst
+++ b/docs/source/docker/docker-machine-aws.rst
@@ -106,11 +106,11 @@ Set the docker environment in local host.
    Experimental: true
 
   Server:
-   Version:      1.12.5
-   API version:  1.24
-   Go version:   go1.6.4
-   Git commit:   7392c3b
-   Built:        Fri Dec 16 02:30:42 2016
+   Version:      17.10.0-ce
+   API version:  1.33
+   Go version:   go1.8.3
+   Git commit:   f4ffd25
+   Built:        Tue Oct 17 19:02:56 2017
    OS/Arch:      linux/amd64
   ➜  ~
 

--- a/docs/source/docker/docker-machine-aws.rst
+++ b/docs/source/docker/docker-machine-aws.rst
@@ -36,54 +36,46 @@ Create a docker machine
   To see how to connect your Docker Client to the Docker Engine running on this virtual machine, run: docker-machine env aws-swarm-manager
   ➜  ~ docker-machine ls
   NAME                ACTIVE   DRIVER      STATE     URL                         SWARM   DOCKER    ERRORS
-  aws-swarm-manager   -        amazonec2   Running   tcp://54.183.145.111:2376           v1.12.5
+  aws-swarm-manager   -        amazonec2   Running   tcp://54.183.145.111:2376           v17.10.0-ce 
   ➜  ~
 
-Please pay attention to ``amazonec2-ami``, please chose a ``Ubuntu 14:04``.
+Please pay attention to ``amazonec2-ami``, please chose a ``Ubuntu 16:04``.
 
 After created, We can use ``docker-machine ssh`` to access the host.
 
 .. code-block:: bash
 
   ➜  ~ docker-machine ssh aws-swarm-manager
-  Welcome to Ubuntu 14.04.5 LTS (GNU/Linux 3.13.0-105-generic x86_64)
 
-   * Documentation:  https://help.ubuntu.com/
+  Welcome to Ubuntu 16.04.3 LTS (GNU/Linux 4.4.0-1038-aws x86_64)
 
-    System information as of Sun Dec 18 15:45:47 UTC 2016
-
-    System load:  0.56              Processes:              109
-    Usage of /:   8.4% of 15.61GB   Users logged in:        0
-    Memory usage: 11%               IP address for eth0:    172.31.25.235
-    Swap usage:   0%                IP address for docker0: 172.17.0.1
-
-    Graph this data and manage this system at:
-      https://landscape.canonical.com/
+  * Documentation:  https://help.ubuntu.com
+  * Management:     https://landscape.canonical.com
+  * Support:        https://ubuntu.com/advantage
 
     Get cloud support with Ubuntu Advantage Cloud Guest:
       http://www.ubuntu.com/business/services/cloud
 
-  New release '16.04.1 LTS' available.
-  Run 'do-release-upgrade' to upgrade to it.
-
-
-  *** System restart required ***
+  4 packages can be updated.
+  1 update is a security update.
+  
   ubuntu@aws-swarm-manager:~$ sudo docker version
   Client:
-   Version:      1.12.5
-   API version:  1.24
-   Go version:   go1.6.4
-   Git commit:   7392c3b
-   Built:        Fri Dec 16 02:30:42 2016
+   Version:      17.10.0-ce
+   API version:  1.33
+   Go version:   go1.8.3
+   Git commit:   f4ffd25
+   Built:        Tue Oct 17 19:04:16 2017
    OS/Arch:      linux/amd64
-
+  
   Server:
-   Version:      1.12.5
-   API version:  1.24
-   Go version:   go1.6.4
-   Git commit:   7392c3b
-   Built:        Fri Dec 16 02:30:42 2016
+   Version:      17.10.0-ce
+   API version:  1.33 (minimum version 1.12)
+   Go version:   go1.8.3
+   Git commit:   f4ffd25
+   Built:        Tue Oct 17 19:02:56 2017
    OS/Arch:      linux/amd64
+   Experimental: false
   ubuntu@aws-swarm-manager:~$
 
 You can also use ``docker-machine ip`` to get the ip address of the docker host.

--- a/docs/source/docker/docker-machine-aws.rst
+++ b/docs/source/docker/docker-machine-aws.rst
@@ -15,7 +15,7 @@ Create a docker machine
   ➜  ~ docker-machine create --driver amazonec2 --amazonec2-region us-west-1 \
                              --amazonec2-zone a --amazonec2-vpc-id vpc-32c73756 \
                              --amazonec2-subnet-id subnet-16c84872 \
-                             --amazonec2-ami ami-7790c617 \
+                             --amazonec2-ami ami-1b17257b \
                              --amazonec2-access-key $AWS_ACCESS_KEY_ID \
                              --amazonec2-secret-key $AWS_SECRET_ACCESS_KEY \
                              aws-swarm-manager


### PR DESCRIPTION
Hello,

calling docker-machine with specified ami leads to error:
```
Error checking TLS connection: Error checking and/or regenerating the certs: There was an error validating certificates for host "54.183.238.197:2376": read tcp 192.168.1.92:52662->54.183.238.197:2376: read: connection reset by peer
You can attempt to regenerate them using 'docker-machine regenerate-certs [name]'.
Be advised that this will trigger a Docker daemon restart which might stop running containers.
```
This was a bug in https://github.com/docker/machine/issues/4156 which is fixed now, I've updated ami id to recent ubuntu.