### PR TITLE
Fix vagrant infrastructure docker group membership

### DIFF
--- a/lab/docker/multi-node/vagrant/Vagrantfile
+++ b/lab/docker/multi-node/vagrant/Vagrantfile
@@ -39,5 +39,5 @@ Vagrant.configure(2) do |config|
         config.vm.network :private_network, ip: opts[:eth1]
       end
   end
-  config.vm.provision "shell", privileged: true, path: "./setup.sh"
+  config.vm.provision "shell", privileged: false, path: "./setup.sh"
 end

--- a/lab/docker/multi-node/vagrant/setup.sh
+++ b/lab/docker/multi-node/vagrant/setup.sh
@@ -9,7 +9,7 @@ sh get-docker.sh
 
 # start docker service
 sudo groupadd docker
-sudo gpasswd -a ubuntu docker
+sudo gpasswd -a $USER docker
 sudo service docker restart
 
 rm -rf get-docker.sh

--- a/lab/docker/single-node/vagrant-centos7/Vagrantfile
+++ b/lab/docker/single-node/vagrant-centos7/Vagrantfile
@@ -29,5 +29,5 @@ Vagrant.configure(2) do |config|
       config.vm.network :private_network, ip: opts[:eth1]
     end
   end
-  config.vm.provision "shell", privileged: true, path: "./setup.sh"
+  config.vm.provision "shell", privileged: false, path: "./setup.sh"
 end

--- a/lab/docker/single-node/vagrant-centos7/setup.sh
+++ b/lab/docker/single-node/vagrant-centos7/setup.sh
@@ -9,7 +9,7 @@ sh get-docker.sh
 
 # start docker service
 sudo groupadd docker
-sudo gpasswd -a vagrant docker
+sudo gpasswd -a $USER docker
 sudo systemctl start docker
 
 rm -rf get-docker.sh

--- a/lab/docker/single-node/vagrant-ubuntu1604/Vagrantfile
+++ b/lab/docker/single-node/vagrant-ubuntu1604/Vagrantfile
@@ -32,5 +32,5 @@ Vagrant.configure(2) do |config|
         config.vm.network :private_network, ip: opts[:eth1]
       end
   end
-  config.vm.provision "shell", privileged: true, path: "./setup.sh"
+  config.vm.provision "shell", privileged: false, path: "./setup.sh"
 end

--- a/lab/docker/single-node/vagrant-ubuntu1604/setup.sh
+++ b/lab/docker/single-node/vagrant-ubuntu1604/setup.sh
@@ -9,7 +9,7 @@ sh get-docker.sh
 
 # start docker service
 sudo groupadd docker
-sudo gpasswd -a ubuntu docker
+sudo gpasswd -a $USER docker
 sudo service docker restart
 
 rm -rf get-docker.sh


### PR DESCRIPTION
Default `privileged: true` results in a provision from `root` user, which, I assume, is not intended as `setup.sh` uses `sudo`.
`setup.sh` script can use `$USER` variable instead of hardcoded `ubuntu` (which is currently incorrect in case of `ubuntu/xenial64`).